### PR TITLE
Fix service start crashes

### DIFF
--- a/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
+++ b/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
@@ -6,6 +6,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager; 
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -17,6 +18,7 @@ import android.os.RemoteException;
 import android.provider.Settings;
 import android.provider.Settings.SettingNotFoundException;
 import android.text.TextUtils;
+import android.support.v4.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -452,9 +454,15 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
                 .emit(eventName, params);
     }
 
+
     public boolean hasPermissions() {
-        //TODO: implement
-        return true;
+        final Context context = getContext();
+        final String coarseLocationPermission = "android.permission.ACCESS_COARSE_LOCATION";
+        final String fineLocationPermission = "android.permission.ACCESS_FINE_LOCATION";
+        
+        int granted = ContextCompat.checkSelfPermission(context, coarseLocationPermission);
+        granted |=  ContextCompat.checkSelfPermission(context, fineLocationPermission);
+        return granted == PackageManager.PERMISSION_GRANTED;
     }
 
     protected void startAndBindBackgroundService() {
@@ -536,8 +544,10 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
     }
 
     protected Context getContext() {
-        return getActivity().getApplicationContext();
+        return getReactApplicationContext();
     }
+
+
 
     public void persistConfiguration(Config config) throws NullPointerException {
         ConfigurationDAO dao = DAOFactory.createConfigurationDAO(getContext());

--- a/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
+++ b/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
@@ -1,14 +1,11 @@
 package com.marianhello.react;
 
 import android.app.Activity;
-import android.app.Application;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.content.pm.PackageManager; 
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -17,8 +14,6 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.provider.Settings;
 import android.provider.Settings.SettingNotFoundException;
-import android.text.TextUtils;
-import android.support.v4.content.ContextCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -43,6 +38,9 @@ import com.marianhello.logging.LogEntry;
 import com.marianhello.logging.LogReader;
 import com.marianhello.logging.LoggerManager;
 import com.marianhello.utils.Convert;
+import com.marianhello.utils.ErrorConstants;
+import com.marianhello.utils.LocationTools;
+import com.marianhello.utils.ServiceTools;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,7 +61,6 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
     /** Flag indicating whether we have called bind on the service. */
     private Boolean mIsBound = false;
 
-    private Boolean mIsServiceRunning = false;
     private Boolean mIsLocationModeChangeReceiverRegistered = false;
 
     private LocationDAO mDao;
@@ -81,6 +78,8 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
         log = LoggerManager.getLogger(BackgroundGeolocationModule.class);
         log.info("initializing plugin");
     }
+
+    /* Overrides / Lifecycle */
 
     @Override
     public String getName() {
@@ -107,6 +106,366 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
         doUnbindService();
         if (mConfig != null && mConfig.getStopOnTerminate()) {
             stopBackgroundService();
+        }
+    }
+
+    /* Javascript API */
+
+    @ReactMethod
+    public void configure(ReadableMap options, Callback success, Callback error) {
+        Config config = new Config();
+        if (options.hasKey("stationaryRadius")) config.setStationaryRadius((float) options.getDouble("stationaryRadius"));
+        if (options.hasKey("distanceFilter")) config.setDistanceFilter(options.getInt("distanceFilter"));
+        if (options.hasKey("desiredAccuracy")) config.setDesiredAccuracy(options.getInt("desiredAccuracy"));
+        if (options.hasKey("debug")) config.setDebugging(options.getBoolean("debug"));
+        if (options.hasKey("notificationTitle")) config.setNotificationTitle(options.getString("notificationTitle"));
+        if (options.hasKey("notificationText")) config.setNotificationText(options.getString("notificationText"));
+        if (options.hasKey("notificationIconLarge")) config.setLargeNotificationIcon(options.getString("notificationIconLarge"));
+        if (options.hasKey("notificationIconSmall")) config.setSmallNotificationIcon(options.getString("notificationIconSmall"));
+        if (options.hasKey("notificationIconColor")) config.setNotificationIconColor(options.getString("notificationIconColor"));
+        if (options.hasKey("stopOnTerminate")) config.setStopOnTerminate(options.getBoolean("stopOnTerminate"));
+        if (options.hasKey("startOnBoot")) config.setStartOnBoot(options.getBoolean("startOnBoot"));
+        if (options.hasKey("startForeground")) config.setStartForeground(options.getBoolean("startForeground"));
+        if (options.hasKey("locationProvider")) config.setLocationProvider(options.getInt("locationProvider"));
+        if (options.hasKey("interval")) config.setInterval(options.getInt("interval"));
+        if (options.hasKey("fastestInterval")) config.setFastestInterval(options.getInt("fastestInterval"));
+        if (options.hasKey("activitiesInterval")) config.setActivitiesInterval(options.getInt("activitiesInterval"));
+        if (options.hasKey("stopOnStillActivity")) config.setStopOnStillActivity(options.getBoolean("stopOnStillActivity"));
+        if (options.hasKey("url")) config.setUrl(options.getString("url"));
+        if (options.hasKey("httpHeaders")) {
+            HashMap httpHeaders = new HashMap<String, String>();
+            ReadableMap rm = options.getMap("httpHeaders");
+            ReadableMapKeySetIterator it = rm.keySetIterator();
+
+            while (it.hasNextKey()) {
+                String key = it.nextKey();
+                httpHeaders.put(key, rm.getString(key));
+            }
+
+            config.setHttpHeaders(httpHeaders);
+        }
+
+        try {
+            persistConfiguration(config);
+        } catch (NullPointerException e) {
+            log.error("Configuration error: {}", e.getMessage());
+            error.invoke("Configuration error: " + e.getMessage());
+            return;
+        }
+
+        this.mConfig = config;
+        success.invoke(true);
+    }
+
+    @ReactMethod
+    public void start(Callback success, Callback error) {
+        if (mConfig == null) {
+            log.warn("Attempt to start unconfigured service");
+            error.invoke("Plugin not configured. Please call configure method first.");
+            return;
+        }
+
+        try {
+            if (hasRequiredPermissions()) {
+                log.info("Requesting permissions from user");
+                startAndBindBackgroundService();
+                success.invoke(true);
+            } else {
+                //TODO: requestPermissions
+                log.warn("Attempt to start service without location permissions!");
+                error.invoke(ErrorConstants.MISSING_PERMISSION);
+            }
+        } catch (Exception e) {
+            log.error("Error starting location service: {}", e.getMessage());
+            error.invoke(ErrorConstants.GENERIC_ERROR + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void stop(Callback success, Callback error) {
+        try {
+            doUnbindService();
+            stopBackgroundService();
+            success.invoke(true);
+        } catch (Exception e) {
+            log.error("Error stopping location service: {}", e.getMessage());
+            error.invoke(ErrorConstants.GENERIC_ERROR + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void isLocationEnabled(Callback success, Callback error) {
+        log.debug("Location services enabled check");
+        try {
+            success.invoke(isGPSEnabled());
+        } catch (Exception e) {
+            log.error("Error checking location enabled: {}", e.getMessage());
+            error.invoke(ErrorConstants.GENERIC_ERROR + e.getMessage());
+        }
+    }
+
+    /**
+     * Launches an activity to show settings for the application. If the app has been backgrounded
+     * this will invoke the error callback, otherwise it'll launch the settings activity and
+     * and call success.
+     *
+     * @param success React success callback
+     * @param error React error callback
+     */
+    @ReactMethod
+    public void showAppSettings(Callback success, Callback error) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            error.invoke(ErrorConstants.NO_ACTIVITY);
+            return;
+        }
+
+        try {
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.addCategory(Intent.CATEGORY_DEFAULT);
+            intent.setData(Uri.parse("package:" + activity.getApplicationContext().getPackageName()));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+
+            activity.startActivity(intent);
+            success.invoke(true);
+        } catch (Exception e) {
+            log.warn(ErrorConstants.GENERIC_ERROR + e.getMessage());
+            error.invoke(ErrorConstants.GENERIC_ERROR + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void showLocationSettings(Callback success, Callback error) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            error.invoke(ErrorConstants.NO_ACTIVITY);
+            return;
+        }
+
+        try {
+            activity.startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+            success.invoke(true);
+        } catch (Exception e) {
+            log.warn(ErrorConstants.GENERIC_ERROR + e.getMessage());
+            error.invoke(ErrorConstants.GENERIC_ERROR + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void watchLocationMode(Callback success, Callback error) {
+        //TODO: implement
+        error.invoke(ErrorConstants.NOT_IMPLEMENTED);
+    }
+
+    @ReactMethod
+    public void stopWatchingLocationMode(Callback success, Callback error) {
+        //TODO: implement
+        error.invoke(ErrorConstants.NOT_IMPLEMENTED);
+    }
+
+    @ReactMethod
+    public void getLocations(Callback success, Callback error) {
+        WritableArray locationsArray = Arguments.createArray();
+        LocationDAO dao = DAOFactory.createLocationDAO(getReactApplicationContext());
+        try {
+            Collection<BackgroundLocation> locations = dao.getAllLocations();
+            for (BackgroundLocation location : locations) {
+                WritableMap out = Arguments.createMap();
+                Long locationId = location.getLocationId();
+                Integer locationProvider = location.getLocationProvider();
+                if (locationId != null) out.putInt("locationId", Convert.safeLongToInt(locationId));
+                if (locationProvider != null) out.putInt("locationProvider", locationProvider);
+                out.putDouble("time", new Long(location.getTime()).doubleValue());
+                out.putDouble("latitude", location.getLatitude());
+                out.putDouble("longitude", location.getLongitude());
+                out.putDouble("accuracy", location.getAccuracy());
+                out.putDouble("speed", location.getSpeed());
+                out.putDouble("altitude", location.getAltitude());
+                out.putDouble("bearing", location.getBearing());
+
+                locationsArray.pushMap(out);
+            }
+            success.invoke(locationsArray);
+        } catch (Exception e) {
+            log.error("Getting all locations failed: {}", e.getMessage());
+            error.invoke("Converting locations to JSON failed.");
+        }
+    }
+
+    @ReactMethod
+    public void switchMode(ReadableMap options, Callback success, Callback error) {
+        //TODO: implement
+        error.invoke("Not implemented yet");
+    }
+
+    @ReactMethod
+    public void getConfig(Callback success, Callback error) {
+        ConfigurationDAO dao = DAOFactory.createConfigurationDAO(getReactApplicationContext());
+        try {
+            Config config = dao.retrieveConfiguration();
+            WritableMap json = Arguments.createMap();
+            WritableMap httpHeaders = Arguments.createMap();
+            json.putDouble("stationaryRadius", config.getStationaryRadius());
+            json.putInt("distanceFilter", config.getDistanceFilter());
+            json.putInt("desiredAccuracy", config.getDesiredAccuracy());
+            json.putBoolean("debug", config.isDebugging());
+            json.putString("notificationTitle", config.getNotificationTitle());
+            json.putString("notificationText", config.getNotificationText());
+            json.putString("notificationIconLarge", config.getLargeNotificationIcon());
+            json.putString("notificationIconSmall", config.getSmallNotificationIcon());
+            json.putString("notificationIconColor", config.getNotificationIconColor());
+            json.putBoolean("stopOnTerminate", config.getStopOnTerminate());
+            json.putBoolean("startOnBoot", config.getStartOnBoot());
+            json.putBoolean("startForeground", config.getStartForeground());
+            json.putInt("locationProvider", config.getLocationProvider());
+            json.putInt("interval", config.getInterval());
+            json.putInt("fastestInterval", config.getFastestInterval());
+            json.putInt("activitiesInterval", config.getActivitiesInterval());
+            json.putBoolean("stopOnStillActivity", config.getStopOnStillActivity());
+            json.putString("url", config.getUrl());
+            json.putString("syncUrl", config.getSyncUrl());
+            json.putInt("syncThreshold", config.getSyncThreshold());
+            // httpHeaders
+            Iterator<Map.Entry<String, String>> it = config.getHttpHeaders().entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, String> pair = it.next();
+                httpHeaders.putString(pair.getKey(), pair.getValue());
+            }
+            json.putMap("httpHeaders", httpHeaders);
+            json.putInt("maxLocations", config.getMaxLocations());
+
+            success.invoke(json);
+        } catch (Exception e) {
+            log.error("Error getting config: {}", e.getMessage());
+            error.invoke("Error getting config: " + e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void getLogEntries(int limit, Callback success, Callback error) {
+        LogReader logReader = new DBLogReader();
+        WritableArray logEntriesArray = Arguments.createArray();
+        Collection<LogEntry> logEntries = logReader.getEntries(limit);
+        for (LogEntry logEntry : logEntries) {
+            WritableMap out = Arguments.createMap();
+            out.putInt("context", logEntry.getContext());
+            out.putString("level", logEntry.getLevel());
+            out.putString("message", logEntry.getMessage());
+            out.putString("timestamp", new Long(logEntry.getTimestamp()).toString());
+            out.putString("logger", logEntry.getLoggerName());
+
+            logEntriesArray.pushMap(out);
+        }
+
+        success.invoke(logEntriesArray);
+    }
+
+    /* Helpers */
+
+    private void sendEvent(ReactContext reactContext, String eventName, @Nullable WritableMap params) {
+        reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, params);
+    }
+
+
+    protected boolean hasRequiredPermissions() {
+        return LocationTools.hasLocationPermissions(getReactApplicationContext());
+    }
+
+    protected void startAndBindBackgroundService() {
+        startBackgroundService();
+        doBindService();
+    }
+
+    protected void startBackgroundService() {
+        if (isLocationServiceRunning()) { return; }
+
+        Context c = getReactApplicationContext();
+        Intent locationServiceIntent = new Intent(c, LocationService.class);
+        locationServiceIntent.putExtra("config", mConfig);
+        locationServiceIntent.addFlags(Intent.FLAG_FROM_BACKGROUND);
+        // start service to keep service running even if no clients are bound to it
+        c.startService(locationServiceIntent);
+    }
+
+    protected void stopBackgroundService() {
+        if (!isLocationServiceRunning()) { return; }
+
+        log.info("Stopping bg service");
+        Context c = getReactApplicationContext();
+        c.stopService(new Intent(c, LocationService.class));
+    }
+
+    void doBindService() {
+        // Establish a connection with the service.  We use an explicit
+        // class name because there is no reason to be able to let other
+        // applications replace our component.
+        if (mIsBound) { return; }
+
+        mMessenger = new Messenger(new IncomingHandler());
+
+        Context c = getReactApplicationContext();
+        Intent locationServiceIntent = new Intent(c, LocationService.class);
+        locationServiceIntent.putExtra("config", mConfig);
+        c.bindService(locationServiceIntent, mConnection, Context.BIND_IMPORTANT);
+    }
+
+    void doUnbindService () {
+        if (mIsBound) {
+            // If we have received the service, and hence registered with
+            // it, then now is the time to unregister.
+            if (mService != null) {
+                try {
+                    Message msg = Message.obtain(null,
+                            LocationService.MSG_UNREGISTER_CLIENT);
+                    msg.replyTo = mMessenger;
+                    msg.arg1 = MESSENGER_CLIENT_ID;
+                    mService.send(msg);
+                } catch (RemoteException e) {
+                    // There is nothing special we need to do if the service
+                    // has crashed.
+                }
+
+                // Detach our existing connection.
+                getReactApplicationContext().unbindService(mConnection);
+                mIsBound = false;
+            }
+        }
+    }
+
+    protected Activity getActivity() {
+        return this.getCurrentActivity();
+    }
+
+    private void persistConfiguration(Config config) throws NullPointerException {
+        ConfigurationDAO dao = DAOFactory.createConfigurationDAO(getReactApplicationContext());
+        dao.persistConfiguration(config);
+    }
+
+    /**
+     * Returns True if our location service is running, False otherwise
+     * @return True if our location service is running, False otherwise
+     */
+    private boolean isLocationServiceRunning() {
+        return ServiceTools.isServiceRunning(getReactApplicationContext(),
+                LocationService.class.getName());
+    }
+
+    /**
+     * Returns True if the GPS is enabled, False if it's off or if the device doesn't have a
+     * GPS setting.
+     *
+     * @return True if the GPS is enabled, False otherwise
+     */
+    private boolean isGPSEnabled () {
+        try {
+            return LocationTools.isLocationEnabled(getReactApplicationContext());
+        } catch (SettingNotFoundException e) {
+            log.error("Location settings not found: {}", e.getMessage());
+            return false;
         }
     }
 
@@ -219,352 +578,4 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
             mIsBound = false;
         }
     };
-
-    @ReactMethod
-    public void configure(ReadableMap options, Callback success, Callback error) {
-        Config config = new Config();
-        if (options.hasKey("stationaryRadius")) config.setStationaryRadius((float) options.getDouble("stationaryRadius"));
-        if (options.hasKey("distanceFilter")) config.setDistanceFilter(options.getInt("distanceFilter"));
-        if (options.hasKey("desiredAccuracy")) config.setDesiredAccuracy(options.getInt("desiredAccuracy"));
-        if (options.hasKey("debug")) config.setDebugging(options.getBoolean("debug"));
-        if (options.hasKey("notificationTitle")) config.setNotificationTitle(options.getString("notificationTitle"));
-        if (options.hasKey("notificationText")) config.setNotificationText(options.getString("notificationText"));
-        if (options.hasKey("notificationIconLarge")) config.setLargeNotificationIcon(options.getString("notificationIconLarge"));
-        if (options.hasKey("notificationIconSmall")) config.setSmallNotificationIcon(options.getString("notificationIconSmall"));
-        if (options.hasKey("notificationIconColor")) config.setNotificationIconColor(options.getString("notificationIconColor"));
-        if (options.hasKey("stopOnTerminate")) config.setStopOnTerminate(options.getBoolean("stopOnTerminate"));
-        if (options.hasKey("startOnBoot")) config.setStartOnBoot(options.getBoolean("startOnBoot"));
-        if (options.hasKey("startForeground")) config.setStartForeground(options.getBoolean("startForeground"));
-        if (options.hasKey("locationProvider")) config.setLocationProvider(options.getInt("locationProvider"));
-        if (options.hasKey("interval")) config.setInterval(options.getInt("interval"));
-        if (options.hasKey("fastestInterval")) config.setFastestInterval(options.getInt("fastestInterval"));
-        if (options.hasKey("activitiesInterval")) config.setActivitiesInterval(options.getInt("activitiesInterval"));
-        if (options.hasKey("stopOnStillActivity")) config.setStopOnStillActivity(options.getBoolean("stopOnStillActivity"));
-        if (options.hasKey("url")) config.setUrl(options.getString("url"));
-        if (options.hasKey("httpHeaders")) {
-            HashMap httpHeaders = new HashMap<String, String>();
-            ReadableMap rm = options.getMap("httpHeaders");
-            ReadableMapKeySetIterator it = rm.keySetIterator();
-
-            while (it.hasNextKey()) {
-                String key = it.nextKey();
-                httpHeaders.put(key, rm.getString(key));
-            }
-
-            config.setHttpHeaders(httpHeaders);
-        }
-
-        try {
-            persistConfiguration(config);
-        } catch (NullPointerException e) {
-            log.error("Configuration error: {}", e.getMessage());
-            error.invoke("Configuration error: " + e.getMessage());
-            return;
-        }
-
-        this.mConfig = config;
-        success.invoke(true);
-    }
-
-    @ReactMethod
-    public void start(Callback success, Callback error) {
-        if (mConfig == null) {
-            log.warn("Attempt to start unconfigured service");
-            error.invoke("Plugin not configured. Please call configure method first.");
-            return;
-        }
-
-        try {
-            if (hasPermissions()) {
-                log.info("Requesting permissions from user");
-                startAndBindBackgroundService();
-                success.invoke(true);
-            } else {
-                //TODO: requestPermissions
-                log.warn("Attempt to start service without location permissions!");
-                error.invoke("Missing permission to track location!");
-            }
-        } catch (NullPointerException e) {
-            error.invoke("Activity is null: " + e.getMessage());
-        }
-    }
-
-    @ReactMethod
-    public void stop(Callback success, Callback error) {
-        try {
-            doUnbindService();
-            stopBackgroundService();
-            success.invoke(true);
-        } catch (NullPointerException e) {
-            error.invoke("Activity is null: " + e.getMessage());
-        }
-    }
-
-    @ReactMethod
-    public void isLocationEnabled(Callback success, Callback error) {
-        log.debug("Location services enabled check");
-        try {
-            int isLocationEnabled = isLocationEnabled(getContext()) ? 1 : 0;
-            success.invoke(isLocationEnabled);
-        } catch (SettingNotFoundException e) {
-            log.error("Location service checked failed: {}", e.getMessage());
-            error.invoke("Location setting error occured");
-        }
-    }
-
-    @ReactMethod
-    public void showAppSettings(Callback success, Callback error) {
-        try {
-            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-            intent.addCategory(Intent.CATEGORY_DEFAULT);
-            intent.setData(Uri.parse("package:" + getContext().getPackageName()));
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-            getContext().startActivity(intent);
-            success.invoke(true);
-        } catch (NullPointerException e) {
-            error.invoke("Activity was null: " + e.getMessage());
-        }
-    }
-
-    @ReactMethod
-    public void showLocationSettings(Callback success, Callback error) {
-        try {
-            Intent settingsIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-            getActivity().startActivity(settingsIntent);
-            success.invoke(true);
-        } catch (NullPointerException e) {
-            error.invoke("Activity was null: " + e.getMessage());
-        }
-    }
-
-    @ReactMethod
-    public void watchLocationMode(Callback success, Callback error) {
-        //TODO: implement
-        error.invoke("Not implemented yet");
-    }
-
-    @ReactMethod
-    public void stopWatchingLocationMode(Callback success, Callback error) {
-        //TODO: implement
-        error.invoke("Not implemented yet");
-    }
-
-    @ReactMethod
-    public void getLocations(Callback success, Callback error) {
-        WritableArray locationsArray = Arguments.createArray();
-        LocationDAO dao = DAOFactory.createLocationDAO(getContext());
-        try {
-            Collection<BackgroundLocation> locations = dao.getAllLocations();
-            for (BackgroundLocation location : locations) {
-                WritableMap out = Arguments.createMap();
-                Long locationId = location.getLocationId();
-                Integer locationProvider = location.getLocationProvider();
-                if (locationId != null) out.putInt("locationId", Convert.safeLongToInt(locationId));
-                if (locationProvider != null) out.putInt("locationProvider", locationProvider);
-                out.putDouble("time", new Long(location.getTime()).doubleValue());
-                out.putDouble("latitude", location.getLatitude());
-                out.putDouble("longitude", location.getLongitude());
-                out.putDouble("accuracy", location.getAccuracy());
-                out.putDouble("speed", location.getSpeed());
-                out.putDouble("altitude", location.getAltitude());
-                out.putDouble("bearing", location.getBearing());
-
-                locationsArray.pushMap(out);
-            }
-            success.invoke(locationsArray);
-        } catch (Exception e) {
-            log.error("Getting all locations failed: {}", e.getMessage());
-            error.invoke("Converting locations to JSON failed.");
-        }
-    }
-
-    @ReactMethod
-    public void switchMode(ReadableMap options, Callback success, Callback error) {
-        //TODO: implement
-        error.invoke("Not implemented yet");
-    }
-
-    @ReactMethod
-    public void getConfig(Callback success, Callback error) {
-        ConfigurationDAO dao = DAOFactory.createConfigurationDAO(getContext());
-        try {
-            Config config = dao.retrieveConfiguration();
-            WritableMap json = Arguments.createMap();
-            WritableMap httpHeaders = Arguments.createMap();
-            json.putDouble("stationaryRadius", config.getStationaryRadius());
-            json.putInt("distanceFilter", config.getDistanceFilter());
-            json.putInt("desiredAccuracy", config.getDesiredAccuracy());
-            json.putBoolean("debug", config.isDebugging());
-            json.putString("notificationTitle", config.getNotificationTitle());
-            json.putString("notificationText", config.getNotificationText());
-            json.putString("notificationIconLarge", config.getLargeNotificationIcon());
-            json.putString("notificationIconSmall", config.getSmallNotificationIcon());
-            json.putString("notificationIconColor", config.getNotificationIconColor());
-            json.putBoolean("stopOnTerminate", config.getStopOnTerminate());
-            json.putBoolean("startOnBoot", config.getStartOnBoot());
-            json.putBoolean("startForeground", config.getStartForeground());
-            json.putInt("locationProvider", config.getLocationProvider());
-            json.putInt("interval", config.getInterval());
-            json.putInt("fastestInterval", config.getFastestInterval());
-            json.putInt("activitiesInterval", config.getActivitiesInterval());
-            json.putBoolean("stopOnStillActivity", config.getStopOnStillActivity());
-            json.putString("url", config.getUrl());
-            json.putString("syncUrl", config.getSyncUrl());
-            json.putInt("syncThreshold", config.getSyncThreshold());
-            // httpHeaders
-            Iterator<Map.Entry<String, String>> it = config.getHttpHeaders().entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<String, String> pair = it.next();
-                httpHeaders.putString(pair.getKey(), pair.getValue());
-            }
-            json.putMap("httpHeaders", httpHeaders);
-            json.putInt("maxLocations", config.getMaxLocations());
-
-            success.invoke(json);
-        } catch (Exception e) {
-            log.error("Error getting config: {}", e.getMessage());
-            error.invoke("Error getting config: " + e.getMessage());
-        }
-    }
-
-    @ReactMethod
-    public void getLogEntries(int limit, Callback success, Callback error) {
-        LogReader logReader = new DBLogReader();
-        WritableArray logEntriesArray = Arguments.createArray();
-        Collection<LogEntry> logEntries = logReader.getEntries(limit);
-        for (LogEntry logEntry : logEntries) {
-            WritableMap out = Arguments.createMap();
-            out.putInt("context", logEntry.getContext());
-            out.putString("level", logEntry.getLevel());
-            out.putString("message", logEntry.getMessage());
-            out.putString("timestamp", new Long(logEntry.getTimestamp()).toString());
-            out.putString("logger", logEntry.getLoggerName());
-
-            logEntriesArray.pushMap(out);
-        }
-
-        success.invoke(logEntriesArray);
-    }
-
-    private void sendEvent(ReactContext reactContext, String eventName, @Nullable WritableMap params) {
-        reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(eventName, params);
-    }
-
-
-    public boolean hasPermissions() {
-        final Context context = getContext();
-        final String coarseLocationPermission = "android.permission.ACCESS_COARSE_LOCATION";
-        final String fineLocationPermission = "android.permission.ACCESS_FINE_LOCATION";
-        
-        int granted = ContextCompat.checkSelfPermission(context, coarseLocationPermission);
-        granted |=  ContextCompat.checkSelfPermission(context, fineLocationPermission);
-        return granted == PackageManager.PERMISSION_GRANTED;
-    }
-
-    protected void startAndBindBackgroundService() {
-        startBackgroundService();
-        doBindService();
-    }
-
-    protected void startBackgroundService() {
-        if (mIsServiceRunning) { return; }
-
-        final Activity currentActivity = this.getCurrentActivity();
-        Intent locationServiceIntent = new Intent(currentActivity, LocationService.class);
-        locationServiceIntent.putExtra("config", mConfig);
-        locationServiceIntent.addFlags(Intent.FLAG_FROM_BACKGROUND);
-        // start service to keep service running even if no clients are bound to it
-        currentActivity.startService(locationServiceIntent);
-        mIsServiceRunning = true;
-    }
-
-    protected void stopBackgroundService() {
-        if (!mIsServiceRunning) { return; }
-
-        log.info("Stopping bg service");
-        final Activity currentActivity = this.getCurrentActivity();
-        currentActivity.stopService(new Intent(currentActivity, LocationService.class));
-        mIsServiceRunning = false;
-    }
-
-    void doBindService() {
-        // Establish a connection with the service.  We use an explicit
-        // class name because there is no reason to be able to let other
-        // applications replace our component.
-        if (mIsBound) { return; }
-
-        mMessenger = new Messenger(new IncomingHandler());
-
-        final Activity currentActivity = this.getCurrentActivity();
-        Intent locationServiceIntent = new Intent(currentActivity, LocationService.class);
-        locationServiceIntent.putExtra("config", mConfig);
-        currentActivity.bindService(locationServiceIntent, mConnection, Context.BIND_IMPORTANT);
-    }
-
-    void doUnbindService () {
-        if (mIsBound) {
-            // If we have received the service, and hence registered with
-            // it, then now is the time to unregister.
-            if (mService != null) {
-                try {
-                    Message msg = Message.obtain(null,
-                            LocationService.MSG_UNREGISTER_CLIENT);
-                    msg.replyTo = mMessenger;
-                    msg.arg1 = MESSENGER_CLIENT_ID;
-                    mService.send(msg);
-                } catch (RemoteException e) {
-                    // There is nothing special we need to do if the service
-                    // has crashed.
-                }
-
-                // Detach our existing connection.
-                final Activity currentActivity = this.getCurrentActivity();
-
-                if (currentActivity != null) { //workaround for issue RN #9791
-                    // not unbinding from service will cause ServiceConnectionLeaked
-                    // but there is not much we can do about it now
-                    currentActivity.unbindService(mConnection);
-                }
-
-                mIsBound = false;
-            }
-        }
-    }
-
-    protected Activity getActivity() {
-        return this.getCurrentActivity();
-    }
-
-    protected Application getApplication() {
-        return getActivity().getApplication();
-    }
-
-    protected Context getContext() {
-        return getReactApplicationContext();
-    }
-
-
-
-    public void persistConfiguration(Config config) throws NullPointerException {
-        ConfigurationDAO dao = DAOFactory.createConfigurationDAO(getContext());
-        dao.persistConfiguration(config);
-    }
-
-    public static boolean isLocationEnabled(Context context) throws SettingNotFoundException {
-        int locationMode = 0;
-        String locationProviders;
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            locationMode = Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.LOCATION_MODE);
-            return locationMode != Settings.Secure.LOCATION_MODE_OFF;
-
-        } else {
-            locationProviders = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
-            return !TextUtils.isEmpty(locationProviders);
-        }
-    }
 }

--- a/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
+++ b/android/lib/src/main/java/com/marianhello/react/BackgroundGeolocationModule.java
@@ -272,20 +272,30 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
             return;
         }
 
-        if (hasPermissions()) {
-            log.info("Requesting permissions from user");
-            startAndBindBackgroundService();
-            success.invoke(true);
-        } else {
-            //TODO: requestPermissions
+        try {
+            if (hasPermissions()) {
+                log.info("Requesting permissions from user");
+                startAndBindBackgroundService();
+                success.invoke(true);
+            } else {
+                //TODO: requestPermissions
+                log.warn("Attempt to start service without location permissions!");
+                error.invoke("Missing permission to track location!");
+            }
+        } catch (NullPointerException e) {
+            error.invoke("Activity is null: " + e.getMessage());
         }
     }
 
     @ReactMethod
     public void stop(Callback success, Callback error) {
-        doUnbindService();
-        stopBackgroundService();
-        success.invoke(true);
+        try {
+            doUnbindService();
+            stopBackgroundService();
+            success.invoke(true);
+        } catch (NullPointerException e) {
+            error.invoke("Activity is null: " + e.getMessage());
+        }
     }
 
     @ReactMethod
@@ -301,20 +311,30 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
     }
 
     @ReactMethod
-    public void showAppSettings() {
-        Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-        intent.addCategory(Intent.CATEGORY_DEFAULT);
-        intent.setData(Uri.parse("package:" + getContext().getPackageName()));
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-        getContext().startActivity(intent);
+    public void showAppSettings(Callback success, Callback error) {
+        try {
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.addCategory(Intent.CATEGORY_DEFAULT);
+            intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+            getContext().startActivity(intent);
+            success.invoke(true);
+        } catch (NullPointerException e) {
+            error.invoke("Activity was null: " + e.getMessage());
+        }
     }
 
     @ReactMethod
-    public void showLocationSettings() {
-        Intent settingsIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-        getActivity().startActivity(settingsIntent);
+    public void showLocationSettings(Callback success, Callback error) {
+        try {
+            Intent settingsIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+            getActivity().startActivity(settingsIntent);
+            success.invoke(true);
+        } catch (NullPointerException e) {
+            error.invoke("Activity was null: " + e.getMessage());
+        }
     }
 
     @ReactMethod

--- a/android/lib/src/main/java/com/marianhello/utils/ErrorConstants.java
+++ b/android/lib/src/main/java/com/marianhello/utils/ErrorConstants.java
@@ -1,0 +1,12 @@
+package com.marianhello.utils;
+
+/**
+ * Created by jackwink on 6/23/17.
+ */
+
+public class ErrorConstants {
+    public static final String NO_ACTIVITY = "No Activity available for this action.";
+    public static final String GENERIC_ERROR = "Something went wrong on the native side: ";
+    public static final String NOT_IMPLEMENTED = "Not implemented yet.";
+    public static final String MISSING_PERMISSION = "Missing permissions for this action.";
+}

--- a/android/lib/src/main/java/com/marianhello/utils/LocationTools.java
+++ b/android/lib/src/main/java/com/marianhello/utils/LocationTools.java
@@ -1,0 +1,51 @@
+package com.marianhello.utils;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings;
+import android.text.TextUtils;
+
+/**
+ * Created by jackwink on 6/23/17.
+ */
+
+public class LocationTools {
+
+    /**
+     * Returns True if the app has location permissions, False otherwise
+     * @param context App or Activity context
+     * @return True if the app has location permissions, False otherwise
+     */
+    public static boolean hasLocationPermissions(Context context) {
+        String[] permissionGroup = {
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.ACCESS_FINE_LOCATION
+        };
+        return PermissionTools.hasPermissions(context, permissionGroup);
+    }
+
+    public static boolean isLocationEnabled(Context context) throws Settings.SettingNotFoundException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            return apiKitKatPlus_isLocationEnabled(context);
+        }
+        return apiLegacy_isLocationEnabled(context);
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private static boolean apiKitKatPlus_isLocationEnabled(Context context) throws Settings.SettingNotFoundException {
+        int locationMode = Settings.Secure.getInt(context.getContentResolver(),
+                Settings.Secure.LOCATION_MODE);
+        return locationMode != Settings.Secure.LOCATION_MODE_OFF;
+    }
+
+
+
+    private static boolean apiLegacy_isLocationEnabled(Context context) throws Settings.SettingNotFoundException {
+        String locationProviders = Settings.Secure.getString(context.getContentResolver(),
+                Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
+        return !TextUtils.isEmpty(locationProviders);
+    }
+}

--- a/android/lib/src/main/java/com/marianhello/utils/PermissionTools.java
+++ b/android/lib/src/main/java/com/marianhello/utils/PermissionTools.java
@@ -1,0 +1,37 @@
+package com.marianhello.utils;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.v4.content.ContextCompat;
+
+/**
+ * Created by jackwink on 6/23/17.
+ */
+
+public class PermissionTools {
+
+    /**
+     * Returns True if the provided permissions are granted, False otherwise
+     * @param context Application Context
+     * @param permissions Array of permission names, i.e. android.permission.ACCESS_COARSE_LOCATION
+     * @return
+     */
+    public static boolean hasPermissions(Context context, String[] permissions) {
+        int granted = 0; // check permissions returns 0 if the permission is granted, -1 otherwise
+        for (String permission : permissions) {
+            granted |= ContextCompat.checkSelfPermission(context, permission);
+        }
+        return granted == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Returns True if the provided permissions are granted, False otherwise
+     * @param context Application Context
+     * @param permission Permission name to check, i.e. android.permission.ACCESS_COARSE_LOCATION
+     * @return
+     */
+    public static boolean hasPermission(Context context, String permission) {
+        String[] permissions = {permission};
+        return hasPermissions(context, permissions);
+    }
+}

--- a/android/lib/src/main/java/com/marianhello/utils/ServiceTools.java
+++ b/android/lib/src/main/java/com/marianhello/utils/ServiceTools.java
@@ -1,0 +1,29 @@
+package com.marianhello.utils;
+
+import android.app.ActivityManager;
+import android.content.Context;
+
+import java.util.List;
+
+
+public class ServiceTools {
+    private final static String TAG = ServiceTools.class.getName();
+
+    /**
+     * Returns True if a provided service name is running on the system, otherwise returns False.
+     * @param context Application context
+     * @param serviceClassName Service name to check
+     * @return True if running, False otherwise.
+     */
+    public static boolean isServiceRunning(Context appContext, String serviceClassName) {
+        final ActivityManager activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
+        final List<ActivityManager.RunningServiceInfo> services = activityManager.getRunningServices(Integer.MAX_VALUE);
+
+        for (ActivityManager.RunningServiceInfo runningServiceInfo : services) {
+            if (runningServiceInfo.service.getClassName().equals(serviceClassName)){
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
"Fixes" some of the crashes we were seeing in bugsnag:

```
java.lang.NullPointerException Attempt to invoke virtual method 'java.lang.String android.content.Context.getPackageName()' on a null object reference 
    ComponentName.java:128 android.content.ComponentName.<init>
    Intent.java:5283 android.content.Intent.<init>
    BackgroundGeolocationModule.java:475 com.marianhello.react.BackgroundGeolocationModule.doBindService
    BackgroundGeolocationModule.java:442 com.marianhello.react.BackgroundGeolocationModule.startAndBindBackgroundService
    BackgroundGeolocationModule.java:277 com.marianhello.react.BackgroundGeolocationModule.start
    Method.java:-2 java.lang.reflect.Method.invoke
    BaseJavaModule.java:322 com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke
    JavaModuleWrapper.java:158 com.facebook.react.cxxbridge.JavaModuleWrapper.invoke
    NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
    Handler.java:739 android.os.Handler.handleCallback
    Handler.java:95 android.os.Handler.dispatchMessage
    MessageQueueThreadHandler.java:31 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
    Looper.java:158 android.os.Looper.loop
    MessageQueueThreadImpl.java:196 com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run
    Thread.java:818 java.lang.Thread.run
```