### PR TITLE
Fix crash on bad location update

### DIFF
--- a/android/lib/src/main/java/com/tenforwardconsulting/bgloc/DistanceFilterLocationProvider.java
+++ b/android/lib/src/main/java/com/tenforwardconsulting/bgloc/DistanceFilterLocationProvider.java
@@ -252,7 +252,7 @@ public class DistanceFilterLocationProvider extends AbstractLocationProvider imp
     public void onLocationChanged(Location location) {
         log.debug("Location change: {} isMoving={}", location.toString(), isMoving);
 
-        if (!isMoving && !isAcquiringStationaryLocation && stationaryLocation==null) {
+        if (!isMoving && !isAcquiringStationaryLocation && stationaryLocation == null) {
             // Perhaps our GPS signal was interupted, re-acquire a stationaryLocation now.
             setPace(false);
         }
@@ -394,12 +394,19 @@ public class DistanceFilterLocationProvider extends AbstractLocationProvider imp
 
     public void onPollStationaryLocation(Location location) {
         float stationaryRadius = config.getStationaryRadius();
+        if (stationaryLocation == null) {
+            stationaryLocation = location;
+        }
+
         if (isMoving) {
             return;
         }
+
         if (config.isDebugging()) {
             startTone(Tone.BEEP);
         }
+
+
         float distance = abs(location.distanceTo(stationaryLocation) - stationaryLocation.getAccuracy() - location.getAccuracy());
 
         if (config.isDebugging()) {


### PR DESCRIPTION
Fixes a null pointer crash seen in 1.0.3 of our agent app. This occurs
when we get a location update, but don't have an original location to
use to compute a delta.

https://app.bugsnag.com/skurt/skurt-driver/errors/5946eda27887c8001812ec4c?filters%5Bevent.since%5D%5B%5D=30d&filters%5Berror.status%5D%5B%5D=open&filters%5Bversion.seen_in%5D%5B%5D%5Bvalue%5D=1.0.3&filters%5Bversion.seen_in%5D%5B%5D%5Btype%5D=eq